### PR TITLE
Voice Analyzer + меню автолата не лезет в глаза

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -269,7 +269,7 @@
 			S.amount = multiplier
 			S.update_icon()
 
-	if(. == TOPIC_REFRESH && get_dist(user, src) < 2)
+	updateUsrDialog()
 		interact(user)
 
 /obj/machinery/autolathe/update_icon()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -270,7 +270,6 @@
 			S.update_icon()
 
 	updateUsrDialog()
-		interact(user)
 
 /obj/machinery/autolathe/update_icon()
 	icon_state = (panel_open ? "autolathe_t" : "autolathe")

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -269,7 +269,7 @@
 			S.amount = multiplier
 			S.update_icon()
 
-	if(. == TOPIC_REFRESH)
+	if(. == TOPIC_REFRESH && get_dist(user, src) < 2)
 		interact(user)
 
 /obj/machinery/autolathe/update_icon()

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -361,6 +361,11 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	name = "igniter"
 	path = /obj/item/device/assembly/igniter
 	category = "Devices and Components"
+	
+/datum/autolathe/recipe/voice
+	name = "voice analyzer"
+	path = /obj/item/device/assembly/voice
+	category = "Devices and Components"
 
 /datum/autolathe/recipe/signaler
 	name = "signaler"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -681,7 +681,8 @@
 						/obj/item/weapon/wirecutters = 1,
 						/obj/item/weapon/cartridge/signal = 4)
 	contraband = list(/obj/item/device/flashlight = 5,
-					  /obj/item/device/assembly/timer = 2)
+					  /obj/item/device/assembly/timer = 2,
+					  /obj/item/device/assembly/voice = 2)
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
 
 /obj/machinery/vending/assist/antag
@@ -689,6 +690,7 @@
 	contraband = list()
 	products = list(	/obj/item/device/assembly/prox_sensor = 5,
 						/obj/item/device/assembly/signaler = 4,
+						/obj/item/device/assembly/voice = 4,
 						/obj/item/device/assembly/infra = 4,
 						/obj/item/device/assembly/prox_sensor = 4,
 						/obj/item/weapon/handcuffs = 8,
@@ -1105,6 +1107,7 @@
 					/obj/item/device/transfer_valve = 6,
 					/obj/item/device/assembly/timer = 6,
 					/obj/item/device/assembly/signaler = 6,
+					/obj/item/device/assembly/voice = 6,
 					/obj/item/device/assembly/prox_sensor = 6,
 					/obj/item/device/assembly/igniter = 6)
 


### PR DESCRIPTION
Здравия!
В соответствии с иссуем про анализаторы голоса добавил оные в автолат и также в вендоматы: в обычном вендомате их два и появляются только если взломано; в вендомате антагов их четыре и в вендомате токсинщиков шесть.
Ну и ещё вообще не понимаю, почему, если поставил в автолате печататься предмет и закрыл его меню, это меню открывается даже когда человек отошёл от автолата и, соответственно, взаимодействовать с ним уже не может. Сделал так, что оно заново открывается только если человек рядом с автолатом.